### PR TITLE
Fix incorrect offset when no gesture events

### DIFF
--- a/slider/src/main/java/com/smarttoolfactory/slider/ColorfulSlider.kt
+++ b/slider/src/main/java/com/smarttoolfactory/slider/ColorfulSlider.kt
@@ -214,6 +214,13 @@ fun ColorfulSlider(
             value
         )
 
+        LaunchedEffect(valueRange) {
+            onValueChangeState.value(
+                value,
+                Offset(x = rawOffset.value.coerceIn(trackStart, trackEnd), y = strokeRadius)
+            )
+        }
+
         val coerced = value.coerceIn(valueRange.start, valueRange.endInclusive)
         val fraction = calculateFraction(valueRange.start, valueRange.endInclusive, coerced)
 


### PR DESCRIPTION
Fix incorrect offset when no gesture events

 | initial    | After dragging     |
| :---:   | :---: | 
 | ![actual](https://github.com/SmartToolFactory/Compose-Colorful-Sliders/assets/55677874/0148eb47-52ca-4c40-b9c2-0e46698a0e06)   | ![expect](https://github.com/SmartToolFactory/Compose-Colorful-Sliders/assets/55677874/351af72c-276c-4ea8-86b1-350e575a7231)   |